### PR TITLE
Add version flag to git-review CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ cd git-review
 go build .
 ```
 
-### Method 2: Go Install (Coming Soon)
+### Method 2: Go Install
 
 ```bash
 go install github.com/gifflet/git-review@latest
@@ -67,6 +67,7 @@ git-review <initial_commit> [final_commit] [options]
 
 - `<initial_commit>`: **Required**. Starting commit hash for comparison
 - `[final_commit]`: **Optional**. Ending commit hash (defaults to `HEAD`)
+- `--version, -v`: Optional. Display the current version of git-review
 - `--main-branch <branch_name>`: Optional main branch for refined comparisons
 - `--project-path <path>`: Optional project directory path
 - `--output-dir <path>`: Optional output directory for diff files

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module git-review
+module github.com/gifflet/git-review
 
 go 1.20

--- a/main.go
+++ b/main.go
@@ -8,6 +8,12 @@ import (
 	"strings"
 )
 
+var AppVersion = "dev"
+
+func showVersion() {
+	fmt.Printf("git-review version %s\n", AppVersion)
+}
+
 func formatCommitHash(hash string) string {
 	if len(hash) < 7 {
 		return hash
@@ -19,6 +25,12 @@ func main() {
 	if len(os.Args) < 2 {
 		fmt.Println("Usage: git-review <initial_commit> [final_commit] [--main-branch <branch_name>] [--project-path <path>] [--output-dir <path>]")
 		os.Exit(1)
+	}
+
+	// Add version flag check
+	if os.Args[1] == "--version" || os.Args[1] == "-v" {
+		showVersion()
+		os.Exit(0)
 	}
 
 	initialCommit := formatCommitHash(os.Args[1])


### PR DESCRIPTION
This PR introduces a --version (-v) flag to git-review, allowing users to check the current version of the tool. The implementation includes a new showVersion function and an AppVersion variable. Additionally, the module path in go.mod has been updated to reference the GitHub repository.